### PR TITLE
Allow phrase candidate selection with digits only

### DIFF
--- a/SetupCompositionProcesseorEngine.cpp
+++ b/SetupCompositionProcesseorEngine.cpp
@@ -1509,8 +1509,9 @@ void CCompositionProcessorEngine::SetupCandidateListRange(IME_MODE imeMode)
 		}
 		if (pNewPhraseIndexRange != nullptr)
 		{
-			StringCchCopy(phraseSelKey, MAX_CAND_SELKEY, L"!@#$%^&*()");
-			pNewPhraseIndexRange->Printable = phraseSelKey[i];
+                       // Use digit keys for phrase candidate selection so SHIFT is not required.
+                       StringCchCopy(phraseSelKey, MAX_CAND_SELKEY, L"1234567890");
+                       pNewPhraseIndexRange->Printable = phraseSelKey[i];
 			
 			UINT vKey, modifier;
 			GetVKeyFromPrintable(phraseSelKey[i], &vKey, &modifier);
@@ -1518,15 +1519,13 @@ void CCompositionProcessorEngine::SetupCandidateListRange(IME_MODE imeMode)
 			pNewPhraseIndexRange->Modifiers = modifier;
 			if (i != 9)
 			{
-				pNewPhraseIndexRange->Index = i + 1;
-				pNewPhraseIndexRange->CandIndex = WCHAR(i + 1 +0x30);  //ASCII 0x3x = x 
-				pNewPhraseIndexRange->Modifiers = TF_MOD_SHIFT;
+                               pNewPhraseIndexRange->Index = i + 1;
+                               pNewPhraseIndexRange->CandIndex = WCHAR(i + 1 +0x30);  //ASCII 0x3x = x
 			}
 			else
 			{
-				pNewPhraseIndexRange->CandIndex = L'0';
-				pNewPhraseIndexRange->Index = 0;
-				pNewPhraseIndexRange->Modifiers = TF_MOD_SHIFT;
+                               pNewPhraseIndexRange->CandIndex = L'0';
+                               pNewPhraseIndexRange->Index = 0;
 
 			}
 


### PR DESCRIPTION
## Summary
- adjust phrase candidate keys to use digits without shift
- drop the forced `TF_MOD_SHIFT` modifier when indexing phrase candidates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dfb3cf8488330bdecd3fdc749e569