### PR TITLE
Improve DPI scaling for candidate and scrollbar windows

### DIFF
--- a/BuildInfo.h
+++ b/BuildInfo.h
@@ -1,12 +1,12 @@
 #define BUILD_VER_MAJOR 1 
 #define BUILD_VER_MINOR 2 
-#define BUILD_COMMIT_COUNT 386 
-#define BUILD_YEAR_4 週一 2 
+#define BUILD_COMMIT_COUNT 401 
+#define BUILD_YEAR_4 週日 2 
 #define BUILD_YEAR_2  2 
 #define BUILD_YEAR_1  2 
 #define BUILD_MONTH 26 
 #define BUILD_DAY 01 
 #define BUILD_DATE_1  22601 
-#define BUILD_DATE_4 週一 22601 
-#define BUILD_VERSION 1.2.386. 22601 
-#define BUILD_VERSION_STR "1.2.386. 22601" 
+#define BUILD_DATE_4 週日 22601 
+#define BUILD_VERSION 1.2.401. 22601 
+#define BUILD_VERSION_STR "1.2.401. 22601" 

--- a/CandidateWindow.h
+++ b/CandidateWindow.h
@@ -61,7 +61,7 @@ public:
 	void _SetCandIndexRange(CCandidateRange* pIndexRange){ _pIndexRange = pIndexRange; }
 
 	void _SetCandStringLength(_In_ UINT wndWidth) { _wndWidth = wndWidth; } // in chararacters
-	UINT _GetWidth() { return _cxTitle + GetSystemMetrics(SM_CXVSCROLL) * 3/2  + CANDWND_BORDER_WIDTH *2;}
+	UINT _GetWidth();
 
 
     void _Move(int x, int y);
@@ -125,6 +125,7 @@ private:
     // DPI 支援函數 - Windows 10 1607+ (向下相容)
     UINT _GetDpiForWindow();
     int _ScaleByDPI(int value);
+    int _GetSystemMetricsForDpi(int nIndex);
 
     friend COLORREF _AdjustTextColor(_In_ COLORREF crColor, _In_ COLORREF crBkColor);
 

--- a/ScrollBarWindow.cpp
+++ b/ScrollBarWindow.cpp
@@ -371,6 +371,10 @@ void CScrollBarWindow::_Resize(int x, int y, int cx, int cy)
 {
     CBaseWindow::_Resize(x, y, cx, cy);
 
+    // 更新按鈕尺寸為傳入的寬度（已由 CCandidateWindow 進行 DPI 縮放）
+    _sizeOfScrollBtn.cx = cx;
+    _sizeOfScrollBtn.cy = cx;  // 按鈕為正方形
+
     RECT rc = {0, 0, 0, 0};
 
     _GetBtnUpRect(&rc);
@@ -458,11 +462,12 @@ void CScrollBarWindow::_AdjustWindowPos()
     }
 
     GetWindowRect(pParent->_GetWnd(), &rc);
+    // 使用已儲存的按鈕尺寸（由 _Resize() 設定，已包含 DPI 縮放）
+    // 注意：CANDWND_BORDER_WIDTH 的縮放由父視窗處理，這裡只需維持相對位置
 	SetWindowPos(_GetWnd(), pParent->_GetWnd(),
-		rc.left + (rc.right - rc.left) - GetSystemMetrics(SM_CXVSCROLL) * 3/2 - CANDWND_BORDER_WIDTH,
+		rc.left + (rc.right - rc.left) - _sizeOfScrollBtn.cx - CANDWND_BORDER_WIDTH,
         rc.top + CANDWND_BORDER_WIDTH,
-        
-		GetSystemMetrics(SM_CXVSCROLL) *3/ 2,
+        _sizeOfScrollBtn.cx,
 		rc.bottom - rc.top - CANDWND_BORDER_WIDTH * 2,
         SWP_NOOWNERZORDER | SWP_NOACTIVATE);
 }


### PR DESCRIPTION
Refactored candidate window and scrollbar window code to use DPI-aware system metrics, ensuring correct sizing and positioning on high-DPI displays. Introduced _GetSystemMetricsForDpi and updated related calculations. Updated build info for new commit count and version.