### PR TITLE
Fix Zhuyin input not working after switching from Array 30

### DIFF
--- a/ActiveLanguageProfileNotifySink.cpp
+++ b/ActiveLanguageProfileNotifySink.cpp
@@ -77,7 +77,7 @@ STDAPI CDIME::OnActivated(_In_ REFCLSID clsid, _In_ REFGUID guidProfile, _In_ BO
 		debugPrint(L"activating with imeMode = %d", Global::imeMode);
 		_pCompositionProcessorEngine->SetImeMode(guidProfile);
 
-		if (!_AddTextProcessorEngine())  return S_OK;
+		if (!_AddTextProcessorEngine(TEXTSERVICE_LANGID, guidProfile))  return S_OK;
 
 		ShowAllLanguageBarIcons();
 

--- a/KeyProcesser.cpp
+++ b/KeyProcesser.cpp
@@ -742,7 +742,7 @@ BOOL CCompositionProcessorEngine::IsVirtualKeyNeed(UINT uCode, _In_reads_(1) WCH
 BOOL CCompositionProcessorEngine::IsVirtualKeyKeystrokeComposition(UINT uCode, PWCH pwch, _Inout_opt_ _KEYSTROKE_STATE* pKeyState, KEYSTROKE_FUNCTION function)
 {
 	
-	if (!IsDictionaryAvailable(_imeMode) || pKeyState == nullptr || _KeystrokeComposition.Count() == 0)
+	if (!IsDictionaryAvailable(Global::imeMode) || pKeyState == nullptr || _KeystrokeComposition.Count() == 0)
 	{
 		return FALSE;
 	}


### PR DESCRIPTION
## Summary
- Fix `OnActivated()` not passing the activated profile GUID to `_AddTextProcessorEngine()`, causing it to use `GetDefaultLanguageProfile()` which returns the old/default profile instead of the newly activated one — resulting in dictionary and keystroke tables never being loaded for the switched-to mode (e.g. Zhuyin)
- Fix `IsVirtualKeyKeystrokeComposition()` using stale `_imeMode` member instead of `Global::imeMode`, consistent with the rest of the codebase

## Test plan
- [x] Switch from Array 30 to Zhuyin and verify Zhuyin input works correctly
- [x] Switch from Zhuyin back to Array 30 and verify Array 30 still works
- [x] Test switching between all input methods (Dayi, Array, Zhuyin, Generic)
- [x] Verify first-time activation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)